### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run Sirius clone this repository and invoke the containers with `docker-compo
 ```
 git clone https://github.com/SiriusScan/Sirius.git
 cd Sirius
-docker-compose up
+docker compose up
 ```
 
 ### Logging in


### PR DESCRIPTION
`docker-compose up` works for v1, but v1 doesn't get updates anymore.  The syntax for v2 is `docker compose up`